### PR TITLE
Fixed a bug where if the user hasn't select a layer, the plugin would fail.

### DIFF
--- a/BoundingBox_dialog.py
+++ b/BoundingBox_dialog.py
@@ -57,6 +57,12 @@ class BoundingBoxDialog(QtWidgets.QDialog, FORM_CLASS):
         bb=str(bb1)
         self.textOutput.setText(bb)
         layer = iface.activeLayer()
+
+        # Stop here if the user hasn't selected a layer.
+        if not layer:
+            return
+
+        # The user has selected a layer, try to extract information about it.
         urlsearch = "<tr><td>GetCapabilitiesUrl</td><td>(.+?)</td>"
         urlresult = re.search(urlsearch, layer.htmlMetadata())
         if(urlresult != None):        


### PR DESCRIPTION
Your plugin is simple but really useful! 

I just use it to get the bounding box of the current map and don't need any information about the GetMap request made if a WMS layer was selected in the first place.

Have you ever considered to rephrase the purpose of the plugin to be just to extract the bounding box of the current map and if a layer was selected give the user options to extract a GetMap request for WMS layers or maybe other information if the layer is a PostGIS/Oracle/... layer?